### PR TITLE
Fix: support null in get fee_rate_statics

### DIFF
--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -748,6 +748,24 @@ describe('Test with mock', () => {
       })
     })
 
+    it('get fee fate statistics of null', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: null,
+          id,
+        },
+      })
+      const res = await rpc.getFeeRateStats()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_fee_rate_statics',
+        params: [],
+      })
+      expect(res).toEqual(null)
+    })
+
     it('local node info', async () => {
       axiosMock.mockResolvedValue({
         data: {

--- a/packages/ckb-sdk-rpc/src/Base/index.ts
+++ b/packages/ckb-sdk-rpc/src/Base/index.ts
@@ -351,7 +351,7 @@ export interface Base {
 
   /* skip Subscription */
 
-  getFeeRateStats: () => Promise<CKBComponents.FeeRateStats>
+  getFeeRateStats: () => Promise<CKBComponents.FeeRateStats | null>
 }
 
 export class Base {


### PR DESCRIPTION
What problem does this PR solve?
------
As title.

Check List
------


### Test
e2e Test
### Task
none
