### PR TITLE
Release v0.109.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.109.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.107.0...v0.109.0) (2023-04-26)
+
+**Note:** Version bump only for package ckb-sdk-js
+
+
+
+
+
 # [0.107.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.103.1...v0.107.0) (2023-04-03)
 
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 | Service  | Master                                                                                                                                                   | Develop                                                                                                                                                    |
 | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Unit Tests   | [![Unit Tests](https://github.com/nervosnetwork/ckb-sdk-js/workflows/Unit%20Tests/badge.svg?branch=master)](https://github.com/nervosnetwork/ckb-sdk-js/actions?query=branch%3Amaster+workflow%3A%22Unit+Tests%22)                      | [![Unit Tests](https://github.com/nervosnetwork/ckb-sdk-js/workflows/Unit%20Tests/badge.svg?branch=develop)](https://github.com/nervosnetwork/ckb-sdk-js/actions?query=branch%3Adevelop+workflow%3A%22Unit+Tests%22)                       |
-| Coverage | [![Codecov](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/master/graph/badge.svg)](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/master) | [![Codecov](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/develop/graph/badge.svg)](https://codecov.io/gh/nervosnetwork/ckb-sdk-js/branch/develop) |
+| Unit Tests   | [![Unit Tests](https://github.com/ckb-js/ckb-sdk-js/workflows/Unit%20Tests/badge.svg?branch=master)](https://github.com/ckb-js/ckb-sdk-js/actions?query=branch%3Amaster+workflow%3A%22Unit+Tests%22)                      | [![Unit Tests](https://github.com/ckb-js/ckb-sdk-js/workflows/Unit%20Tests/badge.svg?branch=develop)](https://github.com/ckb-js/ckb-sdk-js/actions?query=branch%3Adevelop+workflow%3A%22Unit+Tests%22)                       |
+| Coverage | [![Codecov](https://codecov.io/gh/ckb-js/ckb-sdk-js/branch/master/graph/badge.svg)](https://codecov.io/gh/ckb-js/ckb-sdk-js/branch/master) | [![Codecov](https://codecov.io/gh/ckb-js/ckb-sdk-js/branch/develop/graph/badge.svg)](https://codecov.io/gh/ckb-js/ckb-sdk-js/branch/develop) |
 
 [![NPM](https://img.shields.io/npm/v/@nervosnetwork/ckb-sdk-core/latest.svg)](https://www.npmjs.com/package/@nervosnetwork/ckb-sdk-core)
 [![Package Quality](https://npm.packagequality.com/shield/%40nervosnetwork%2Fckb-sdk-core.svg)](https://packagequality.com/#?package=@nervosnetwork/ckb-sdk-core)
 [![License](https://img.shields.io/npm/l/@nervosnetwork/ckb-sdk-core.svg)](./LICENSE)
 [![Telegram Group](https://cdn.rawgit.com/Patrolavia/telegram-badge/8fe3382b/chat.svg)](https://t.me/nervos_ckb_dev)
-[![SNYK](https://github.com/nervosnetwork/ckb-sdk-js/workflows/SNYK/badge.svg)](https://github.com/nervosnetwork/ckb-sdk-js/actions?query=workflow%3ASNYK)
-[![Deploy Docs](https://github.com/nervosnetwork/ckb-sdk-js/workflows/Deploy%20Docs/badge.svg)](https://nervosnetwork.github.io/ckb-sdk-js/classes/_nervosnetwork_ckb_sdk_core.default.html)
+[![SNYK](https://github.com/ckb-js/ckb-sdk-js/workflows/SNYK/badge.svg)](https://github.com/ckb-js/ckb-sdk-js/actions?query=workflow%3ASNYK)
+[![Deploy Docs](https://github.com/ckb-js/ckb-sdk-js/workflows/Deploy%20Docs/badge.svg)](https://nervosnetwork.github.io/ckb-sdk-js/classes/_nervosnetwork_ckb_sdk_core.default.html)
 
 JavaScript SDK for Nervos [CKB](https://github.com/nervosnetwork/ckb).
 
@@ -91,7 +91,7 @@ This SDK includes several modules:
 
 <details>
 <summary>
-  RPC <a href="https://github.com/nervosnetwork/ckb-sdk-js/tree/develop/packages/ckb-sdk-rpc" alt="rpc">Code</a>
+  RPC <a href="https://github.com/ckb-js/ckb-sdk-js/tree/develop/packages/ckb-sdk-rpc" alt="rpc">Code</a>
 </summary>
 <dd>
 
@@ -105,7 +105,7 @@ Interfaces could be found in `DefaultRPC` class in this module.
 
 <details>
 <summary>
-  Utils <a href="https://github.com/nervosnetwork/ckb-sdk-js/tree/develop/packages/ckb-sdk-utils" alt="utils">Code</a>
+  Utils <a href="https://github.com/ckb-js/ckb-sdk-js/tree/develop/packages/ckb-sdk-utils" alt="utils">Code</a>
 </summary>
 <dd>
 
@@ -116,7 +116,7 @@ The Utils module provides useful methods for other modules.
 
 <details>
 <summary>
-  Types <a href="https://github.com/nervosnetwork/ckb-sdk-js/tree/develop/packages/ckb-types" alt="types">Code</a>
+  Types <a href="https://github.com/ckb-js/ckb-sdk-js/tree/develop/packages/ckb-types" alt="types">Code</a>
 </summary>
 <dd>
 
@@ -149,7 +149,7 @@ After that you can use the `ckb` object to generate addresses, send requests, et
 
 ## Basic RPC
 
-Please see [Basic RPC](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/Base/index.ts#L23)
+Please see [Basic RPC](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/Base/index.ts#L23)
 
 ## Batch Request
 
@@ -217,7 +217,7 @@ ckb.rpc.setNode({ httpsAgent })
 
 # Utils
 
-[Most used utilities](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-utils/README.md)
+[Most used utilities](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-utils/README.md)
 
 # Errors
 
@@ -227,12 +227,12 @@ The rpc module will throw an error when the result contains an error field, you 
 
 # Examples
 
-1. [Send Simple Transaction](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendSimpleTransaction.js)
-2. [Send All Balance](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendAllBalance.js)
-3. [Send Transaction with multiple private key](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithMultiplePrivateKey.js)
-4. [Deposit to and withdraw from Nervos DAO](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/nervosDAO.js)
-5. [Send Transaction with Lumos Collector](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js)
-6. [SUDT](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sudt.js)
+1. [Send Simple Transaction](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendSimpleTransaction.js)
+2. [Send All Balance](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendAllBalance.js)
+3. [Send Transaction with multiple private key](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithMultiplePrivateKey.js)
+4. [Deposit to and withdraw from Nervos DAO](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/nervosDAO.js)
+5. [Send Transaction with Lumos Collector](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js)
+6. [SUDT](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sudt.js)
 
 # Troubleshooting
 
@@ -240,7 +240,7 @@ The rpc module will throw an error when the result contains an error field, you 
 
 The Indexer Module in CKB has been deprecated since [v0.36.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.36.0), please use [ckb-indexer](https://github.com/nervosnetwork/ckb-indexer) or [lumos-indexer](https://github.com/nervosnetwork/lumos/tree/develop/packages/indexer) instead.
 
-A simple example [sendTransactionWithLumosCollector](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js) of wokring with lumos has beed added.
+A simple example [sendTransactionWithLumosCollector](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js) of wokring with lumos has beed added.
 
 # Development Process
 

--- a/lerna.json
+++ b/lerna.json
@@ -4,5 +4,5 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.107.0"
+  "version": "0.109.0"
 }

--- a/packages/ckb-sdk-core/CHANGELOG.md
+++ b/packages/ckb-sdk-core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.109.0](https://github.com/ckb-js/ckb-sdk-js/compare/v0.107.0...v0.109.0) (2023-04-26)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-core
+
+
+
+
+
 # [0.107.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.103.1...v0.107.0) (2023-04-03)
 
 

--- a/packages/ckb-sdk-core/README.md
+++ b/packages/ckb-sdk-core/README.md
@@ -2,6 +2,6 @@
 
 `@nervosnetwork/ckb-sdk-core` is the JavaScript SDK for Nervos Network [CKB Project](https://github.com/nervosnetwork/ckb)
 
-[Type Doc](https://nervosnetwork.github.io/ckb-sdk-js/classes/ckb.html)
+[Type Doc](https://ckb-js.github.io/ckb-sdk-js/classes/ckb.html)
 
-See [Full Doc](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/README.md)
+See [Full Doc](https://github.com/ckb-js/ckb-sdk-js/blob/develop/README.md)

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -38,5 +38,5 @@
     "@nervosnetwork/ckb-types": "0.109.0",
     "tslib": "2.3.1"
   },
-  "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"
+  "gitHead": "10530318adf792f033abf7e449eaea956c4aea1d"
 }

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -3,7 +3,7 @@
   "version": "0.107.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
-  "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
+  "homepage": "https://github.com/ckb-js/ckb-sdk-js#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -23,14 +23,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/ckb-sdk-js.git"
+    "url": "git+https://github.com/ckb-js/ckb-sdk-js.git"
   },
   "scripts": {
     "tsc": "tsc",
     "test": "../../node_modules/.bin/jest"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
+    "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "dependencies": {
     "@nervosnetwork/ckb-sdk-rpc": "0.107.0",

--- a/packages/ckb-sdk-core/package.json
+++ b/packages/ckb-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-core",
-  "version": "0.107.0",
+  "version": "0.109.0",
   "description": "JavaScript SDK for Nervos Network CKB Project",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/ckb-js/ckb-sdk-js#readme",
@@ -33,9 +33,9 @@
     "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-rpc": "0.107.0",
-    "@nervosnetwork/ckb-sdk-utils": "0.107.0",
-    "@nervosnetwork/ckb-types": "0.107.0",
+    "@nervosnetwork/ckb-sdk-rpc": "0.109.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.109.0",
+    "@nervosnetwork/ckb-types": "0.109.0",
     "tslib": "2.3.1"
   },
   "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"

--- a/packages/ckb-sdk-core/src/index.ts
+++ b/packages/ckb-sdk-core/src/index.ts
@@ -90,7 +90,7 @@ class CKB {
   /**
    * @memberof Core
    * @description The method used to load cells from lumos indexer as shown in the tutorial
-   * @tutorial https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js
+   * @tutorial https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-core/examples/sendTransactionWithLumosCollector.js
    */
   public loadCells = async (
     params: LoadCellsParams.FromIndexer & {

--- a/packages/ckb-sdk-rpc/CHANGELOG.md
+++ b/packages/ckb-sdk-rpc/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.109.0](https://github.com/ckb-js/ckb-sdk-js/compare/v0.107.0...v0.109.0) (2023-04-26)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-rpc
+
+
+
+
+
 # [0.107.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.103.1...v0.107.0) (2023-04-03)
 
 ### Features

--- a/packages/ckb-sdk-rpc/README.md
+++ b/packages/ckb-sdk-rpc/README.md
@@ -2,8 +2,8 @@
 
 `@nervosnetwork/ckb-sdk-rpc` is the rpc module of `@nervosnetwork/ckb-sdk-core`.
 
-RPC list could be found [here](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/Base.ts#L156)
+RPC list could be found [here](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-rpc/src/Base.ts#L156)
 
-[Type Doc](https://nervosnetwork.github.io/ckb-sdk-js/classes/ckbrpc.html)
+[Type Doc](https://ckb-js.github.io/ckb-sdk-js/classes/ckbrpc.html)
 
-See [Full Doc](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/README.md)
+See [Full Doc](https://github.com/ckb-js/ckb-sdk-js/blob/develop/README.md)

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc-helpers.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc-helpers.js
@@ -32,8 +32,8 @@ describe('ckb-rpc settings and helpers', () => {
     expect(rpc.node.httpsAgent).toBeDefined()
   })
 
-  it('has 33 basic rpc', () => {
-    expect(Object.values(rpc)).toHaveLength(33)
+  it('has 34 basic rpc', () => {
+    expect(Object.values(rpc)).toHaveLength(34)
   })
 
   it('set node url to http://test.localhost:8114', () => {

--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -392,7 +392,7 @@ describe('Test with mock', () => {
         startNumber: '0x0',
       })
     })
-    it.skip('dryRunTransaction', async () => {})
+    it.skip('dryRunTransaction', async () => { })
     it('get cellbase output capacity details', async () => {
       const BLOCK_HASH = '0xa5f5c85987a15de25661e5a214f2c1449cd803f071acc7999820f25246471f40'
       axiosMock.mockResolvedValue({
@@ -721,6 +721,30 @@ describe('Test with mock', () => {
         epoch: '0xa00090000e2',
         isInitialBlockDownload: true,
         medianTime: '0x172a87eeab0',
+      })
+    })
+
+    it('get fee fate statistics', async () => {
+      axiosMock.mockResolvedValue({
+        data: {
+          jsonrpc: '2.0',
+          result: {
+            mean: '0xe79d',
+            median: '0x14a8',
+          },
+          id,
+        },
+      })
+      const res = await rpc.getFeeRateStats()
+      expect(axiosMock.mock.calls[0][0].data).toEqual({
+        id,
+        jsonrpc: '2.0',
+        method: 'get_fee_rate_statics',
+        params: [],
+      })
+      expect(res).toEqual({
+        mean: '0xe79d',
+        median: '0x14a8',
       })
     })
 

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -3,7 +3,7 @@
   "version": "0.107.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
-  "homepage": "https://github.com/nervosnetwork/ckb-sdk-js/packages/ckb-rpc#readme",
+  "homepage": "https://github.com/ckb-js/ckb-sdk-js/packages/ckb-rpc#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/ckb-sdk-js.git"
+    "url": "git+https://github.com/ckb-js/ckb-sdk-js.git"
   },
   "scripts": {
     "tsc": "tsc",
@@ -30,7 +30,7 @@
     "test:watch": "../../node_modules/.bin/jest --watch"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
+    "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "dependencies": {
     "@nervosnetwork/ckb-sdk-utils": "0.107.0",

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-rpc",
-  "version": "0.107.0",
+  "version": "0.109.0",
   "description": "RPC module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/ckb-js/ckb-sdk-js/packages/ckb-rpc#readme",
@@ -33,12 +33,12 @@
     "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-sdk-utils": "0.107.0",
+    "@nervosnetwork/ckb-sdk-utils": "0.109.0",
     "axios": "0.21.4",
     "tslib": "2.3.1"
   },
   "devDependencies": {
-    "@nervosnetwork/ckb-types": "0.107.0"
+    "@nervosnetwork/ckb-types": "0.109.0"
   },
   "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"
 }

--- a/packages/ckb-sdk-rpc/package.json
+++ b/packages/ckb-sdk-rpc/package.json
@@ -40,5 +40,5 @@
   "devDependencies": {
     "@nervosnetwork/ckb-types": "0.109.0"
   },
-  "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"
+  "gitHead": "10530318adf792f033abf7e449eaea956c4aea1d"
 }

--- a/packages/ckb-sdk-rpc/src/Base/index.ts
+++ b/packages/ckb-sdk-rpc/src/Base/index.ts
@@ -350,6 +350,8 @@ export interface Base {
   getBlockchainInfo: () => Promise<CKBComponents.BlockchainInfo>
 
   /* skip Subscription */
+
+  getFeeRateStats: () => Promise<CKBComponents.FeeRateStats>
 }
 
 export class Base {

--- a/packages/ckb-sdk-rpc/src/Base/stats.ts
+++ b/packages/ckb-sdk-rpc/src/Base/stats.ts
@@ -6,4 +6,8 @@ export default {
     paramsFormatters: [],
     resultFormatters: resultFmts.toBlockchainInfo,
   },
+  getFeeRateStats: {
+    method: 'get_fee_rate_statics',
+    paramsFormatters: [],
+  },
 }

--- a/packages/ckb-sdk-rpc/types/rpc/index.d.ts
+++ b/packages/ckb-sdk-rpc/types/rpc/index.d.ts
@@ -257,6 +257,11 @@ declare module RPC {
     fee_rate: string
   }
 
+  export type FeeRateStats = {
+    mean: string
+    median: string
+  }
+
   export interface CapacityByLockHash {
     block_number: BlockNumber
     capacity: Capacity

--- a/packages/ckb-sdk-utils/CHANGELOG.md
+++ b/packages/ckb-sdk-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.109.0](https://github.com/ckb-js/ckb-sdk-js/compare/v0.107.0...v0.109.0) (2023-04-26)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils
+
+
+
+
+
 # [0.107.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.103.1...v0.107.0) (2023-04-03)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-sdk-utils

--- a/packages/ckb-sdk-utils/README.md
+++ b/packages/ckb-sdk-utils/README.md
@@ -2,7 +2,7 @@
 
 `@nervosnetwork/ckb-sdk-utils` is the utils module of `@nervosnetwork/ckb-sdk-core`, which provides necessary methods for the sdk, including encryption, key-pair generation, address generation and so on.
 
-See [Full Doc](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/README.md)
+See [Full Doc](https://github.com/ckb-js/ckb-sdk-js/blob/develop/README.md)
 
 ## Most Used Utilities
 
@@ -214,4 +214,4 @@ utils.scriptToHash({
 
 ### System Scripts
 
-[System Scripts](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/packages/ckb-sdk-utils/src/systemScripts.ts)
+[System Scripts](https://github.com/ckb-js/ckb-sdk-js/blob/develop/packages/ckb-sdk-utils/src/systemScripts.ts)

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -41,5 +41,5 @@
     "@types/bitcoinjs-lib": "5.0.0",
     "@types/elliptic": "6.4.12"
   },
-  "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"
+  "gitHead": "10530318adf792f033abf7e449eaea956c4aea1d"
 }

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -3,7 +3,7 @@
   "version": "0.107.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
-  "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
+  "homepage": "https://github.com/ckb-js/ckb-sdk-js#readme",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -21,14 +21,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/ckb-sdk-js.git"
+    "url": "git+https://github.com/ckb-js/ckb-sdk-js.git"
   },
   "scripts": {
     "tsc": "tsc",
     "test": "../../node_modules/.bin/jest"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
+    "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "dependencies": {
     "@nervosnetwork/ckb-types": "0.107.0",

--- a/packages/ckb-sdk-utils/package.json
+++ b/packages/ckb-sdk-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-sdk-utils",
-  "version": "0.107.0",
+  "version": "0.109.0",
   "description": "Utils module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/ckb-js/ckb-sdk-js#readme",
@@ -31,7 +31,7 @@
     "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "dependencies": {
-    "@nervosnetwork/ckb-types": "0.107.0",
+    "@nervosnetwork/ckb-types": "0.109.0",
     "bech32": "2.0.0",
     "elliptic": "6.5.4",
     "jsbi": "3.1.3",

--- a/packages/ckb-types/CHANGELOG.md
+++ b/packages/ckb-types/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.109.0](https://github.com/ckb-js/ckb-sdk-js/compare/v0.107.0...v0.109.0) (2023-04-26)
+
+**Note:** Version bump only for package @nervosnetwork/ckb-types
+
+
+
+
+
 # [0.107.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.103.1...v0.107.0) (2023-04-03)
 
 **Note:** Version bump only for package @nervosnetwork/ckb-types

--- a/packages/ckb-types/README.md
+++ b/packages/ckb-types/README.md
@@ -2,6 +2,6 @@
 
 `@nervosnetwork/ckb-types` is the type definition module for the `@nervosnetwork/ckb-sdk-core` and its modules.
 
-[Type Doc](https://nervosnetwork.github.io/ckb-sdk-js/modules/ckbcomponents.html)
+[Type Doc](https://ckb-js.github.io/ckb-sdk-js/modules/ckbcomponents.html)
 
-See [Full Doc](https://github.com/nervosnetwork/ckb-sdk-js/blob/develop/README.md)
+See [Full Doc](https://github.com/ckb-js/ckb-sdk-js/blob/develop/README.md)

--- a/packages/ckb-types/index.d.ts
+++ b/packages/ckb-types/index.d.ts
@@ -499,4 +499,14 @@ declare namespace CKBComponents {
     primaryEpochRewardHalvingInterval: string
     permanentDifficultyInDummy: boolean
   }
+
+  /**
+   * FeeRateStatistics
+   * mean: Uint64 - mean
+   * median: Uint64 - median
+   */
+  export type FeeRateStats = {
+    mean: string
+    median: string
+  }
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervosnetwork/ckb-types",
-  "version": "0.107.0",
+  "version": "0.109.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
   "homepage": "https://github.com/ckb-js/ckb-sdk-js#readme",

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -20,5 +20,5 @@
   "bugs": {
     "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
-  "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"
+  "gitHead": "10530318adf792f033abf7e449eaea956c4aea1d"
 }

--- a/packages/ckb-types/package.json
+++ b/packages/ckb-types/package.json
@@ -3,7 +3,7 @@
   "version": "0.107.0",
   "description": "Type module of @nervosnetwork/ckb-sdk-core",
   "author": "Nervos <dev@nervos.org>",
-  "homepage": "https://github.com/nervosnetwork/ckb-sdk-js#readme",
+  "homepage": "https://github.com/ckb-js/ckb-sdk-js#readme",
   "license": "MIT",
   "types": "index.d.ts",
   "directories": {
@@ -15,10 +15,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nervosnetwork/ckb-sdk-js.git"
+    "url": "git+https://github.com/ckb-js/ckb-sdk-js.git"
   },
   "bugs": {
-    "url": "https://github.com/nervosnetwork/ckb-sdk-js/issues"
+    "url": "https://github.com/ckb-js/ckb-sdk-js/issues"
   },
   "gitHead": "592c7cb58fd830f8bc07f5f08551811ba0197195"
 }


### PR DESCRIPTION
# [0.109.0](https://github.com/nervosnetwork/ckb-sdk-js/compare/v0.107.0...v0.109.0) (2023-04-26)

- refactor: update RPC name of `get_fee_rate_statistics`, ref: https://github.com/nervosnetwork/ckb/pull/3924