### PR TITLE
fix: return empty array if payload of batch request is an empty array

### DIFF
--- a/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
+++ b/packages/ckb-sdk-rpc/__tests__/ckb-rpc.test.js
@@ -1728,6 +1728,11 @@ describe('Test with mock', () => {
           },
         ])
       })
+
+      it('should return empty array as response if request is an empty array', async () => {
+        const emptyBatch = rpc.createBatchRequest([])
+        expect(await emptyBatch.exec()).toEqual([])
+      })
     })
   })
 

--- a/packages/ckb-sdk-rpc/src/index.ts
+++ b/packages/ckb-sdk-rpc/src/index.ts
@@ -101,6 +101,10 @@ class CKBRPC extends Base {
             }
           })
 
+          if (!payload.length) {
+            return []
+          }
+
           const batchRes = await axios({
             method: 'POST',
             headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
Short circuit batch request with an empty array if request payload is an empty array

Ref: https://github.com/ckb-js/ckb-sdk-js/issues/615